### PR TITLE
Potential fix for code scanning alert no. 4: Type confusion through parameter tampering

### DIFF
--- a/frontend/deckchatbot/controllers/skirtingController.js
+++ b/frontend/deckchatbot/controllers/skirtingController.js
@@ -8,6 +8,9 @@ function toFeetDecimal(feet, inches) {
 // Allow a single value like "10' 6\"" or 10.5 to be converted to feet
 function normalizeMeasurement(ft, inch, combined) {
   if (combined != null) {
+    if (typeof combined !== 'string' && typeof combined !== 'number') {
+      return null; // Reject invalid types
+    }
     const parsed = parseMeasurement(String(combined));
     if (typeof parsed === 'number' && !Number.isNaN(parsed)) {
       return parsed;
@@ -33,6 +36,16 @@ function calculateSkirting(req, res) {
     sides = 4,
     material
   } = req.body;
+
+  if (
+    (length != null && typeof length !== 'string' && typeof length !== 'number') ||
+    (width != null && typeof width !== 'string' && typeof width !== 'number') ||
+    (height != null && typeof height !== 'string' && typeof height !== 'number')
+  ) {
+    return res.status(400).json({
+      errors: [{ msg: 'Invalid input types for length, width, or height.' }]
+    });
+  }
 
   const lengthVal = normalizeMeasurement(lengthFt, lengthIn, length);
   const widthVal = normalizeMeasurement(widthFt, widthIn, width);


### PR DESCRIPTION
Potential fix for [https://github.com/alentwotime/deckchatbot-monorepo/security/code-scanning/4](https://github.com/alentwotime/deckchatbot-monorepo/security/code-scanning/4)

To fix the issue, we need to ensure that all user-controlled inputs from `req.body` are validated to confirm they are of the expected type before further processing. Specifically:
1. Add type checks for `length`, `width`, and `height` parameters in the `calculateSkirting` function to ensure they are strings or numbers, not arrays or other unexpected types.
2. Update the `normalizeMeasurement` function to handle unexpected types more robustly by rejecting non-string and non-number inputs.

This fix will prevent type confusion attacks by ensuring that only valid inputs are processed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate and enforce expected types for user-controlled measurements to prevent type confusion attacks by adding input checks in calculateSkirting and enhancing normalizeMeasurement to reject invalid types.

Bug Fixes:
- Prevent type confusion by rejecting non-string and non-number inputs for length, width, and height in calculateSkirting.

Enhancements:
- Enhance normalizeMeasurement to return null for unexpected input types by validating combined values.