### PR TITLE
Add run script for easier startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ Thumbs.db
 !PROMPT.md
 !LICENSE
 !.env
+!run.sh
+!run.bat
  li58ee-codex/adapt-lowe’s-deck-designer-features-to-deckchatbot
 frontend/memory.sqlite
 frontend/logs/*.json

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ npm install
 npm run dev
 ```
 
+### 4. One-Command Start
+
+If everything is installed, you can run both servers with a single command:
+
+```bash
+./run.sh
+```
+
+This script launches the FastAPI backend (`poetry run uvicorn API.api:app --reload`) and the frontend (`npm run dev`) and waits on both processes.
+
 Then open `http://localhost:3000/deck-viewer.html` in your browser to try the new 3D deck viewer built with Babylon.js. Use the toolbar to render a deck and export blueprint screenshots or a GLB model.
 
 ---

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,12 @@
+@echo off
+if not exist backend-ai\ goto notroot
+if not exist frontend\ goto notroot
+
+start "backend" cmd /k "cd backend-ai && poetry run uvicorn API.api:app --reload"
+start "frontend" cmd /k "cd frontend && npm run dev"
+
+goto :eof
+:notroot
+echo Please run this script from the repository root.
+exit /b 1
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "backend-ai" ] || [ ! -d "frontend" ]; then
+  echo "Please run this script from the repository root." >&2
+  exit 1
+fi
+
+command -v poetry >/dev/null 2>&1 || { echo "poetry is not installed." >&2; exit 1; }
+command -v npm >/dev/null 2>&1 || { echo "npm is not installed." >&2; exit 1; }
+
+trap 'echo "\nStopping servers..."; kill "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null' SIGINT SIGTERM
+
+echo "Starting FastAPI backend..."
+(
+  cd backend-ai
+  poetry run uvicorn API.api:app --reload
+) &
+BACKEND_PID=$!
+
+echo "Starting frontend..."
+(
+  cd frontend
+  npm run dev
+) &
+FRONTEND_PID=$!
+
+wait $BACKEND_PID
+wait $FRONTEND_PID
+


### PR DESCRIPTION
## Summary
- add `run.sh` and Windows `run.bat` scripts to launch backend and frontend
- update `.gitignore` to keep the scripts
- document one-command startup option in README

## Testing
- `npm test` *(fails: jest not found)*
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68519c67895083329026c849451d5f4a

## Summary by Sourcery

Introduce cross-platform startup scripts and document a one-command option to streamline launching the backend and frontend concurrently.

New Features:
- Add run.sh and run.bat scripts for one-command startup launching both backend and frontend

Documentation:
- Document the one-command startup process in the README

Chores:
- Update .gitignore to include the new startup scripts