### PR TITLE
Automate Azure deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ Thumbs.db
 !LICENSE
 !run.sh
 !run.bat
+!azure_setup.sh
+!jest.config.js
 !Azureworkspaces.csv
 !Deckchatbot_Deployment_Guide.md
 !deck-vision.md

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ The frontend will be available at [http://localhost:3000](http://localhost:3000)
 
 Images can be built and pushed to your Azure Container Registry and deployed to Azure Container Apps. A GitHub Actions workflow (`.github/workflows/deploy.yml`) automates this whenever `main` is pushed. It requires `AZURE_CREDENTIALS`, `ACR_NAME` and `AZURE_RG` secrets.
 
+Alternatively you can run the helper script `./azure_setup.sh` after logging in
+with `az login` and exporting `AZURE_RG`, `ACR_NAME` and `LOCATION`. It will
+build and push the Docker images and create the Container Apps for you.
+
 For manual deployment you can run:
 
 ```bash

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testMatch: ["**/__tests__/**/*.js"],
+  moduleDirectories: ['node_modules', 'frontend/node_modules'],
+};


### PR DESCRIPTION
## Summary
- add an `azure_setup.sh` helper script for one-command Azure deployment
- document usage of the new script in README
- allow the new script and Jest config to be committed via `.gitignore`
- include a minimal `jest.config.js` so tests can locate modules

## Testing
- `npm install` *(success)*
- `npm install supertest` *(success)*
- `npm install tesseract.js` *(success)*
- `./frontend/node_modules/.bin/jest --runInBand` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6853c2bd5d58833285420a39d2686e2d