### PR TITLE
Add polygon utilities and OpenAI mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ Thumbs.db
 !Azureworkspaces.csv
 !Deckchatbot_Deployment_Guide.md
 !deck-vision.md
+!server.cjs
+!memory.js
 !.conaarc
 !docker-compose.yml
 !/.github/

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -4,41 +4,41 @@ const config = {
   // Server configuration
   PORT: process.env.PORT || 3000,
   NODE_ENV: process.env.NODE_ENV || 'development',
-  
+
   // Database
   MEM_DB: process.env.MEM_DB || '',
-  
+
   // API Keys
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   API_KEY: process.env.API_KEY || 'revamp123secure',
-  
+
   // Security
   JWT_SECRET: process.env.JWT_SECRET || 'fallback-secret-change-in-production',
-  
+
   // Rate Limiting
   RATE_LIMIT_WINDOW: 15 * 60 * 1000, // 15 minutes
   RATE_LIMIT_MAX: 100, // requests per window
-  
+
   // File Upload
   MAX_FILE_SIZE: 50 * 1024 * 1024, // 50MB
   ALLOWED_FILE_TYPES: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
-  
+
   // Logging
   USE_LOG_EMOJI: process.env.NODE_ENV !== 'production',
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',
-  
+
   // OpenAI
   OPENAI_MODEL: 'gpt-3.5-turbo',
   OPENAI_MAX_TOKENS: 1000,
   OPENAI_TEMPERATURE: 0.7,
-  
+
   // Development
   isDevelopment: process.env.NODE_ENV === 'development',
   isProduction: process.env.NODE_ENV === 'production'
 };
 
 // Validation
-if (!config.OPENAI_API_KEY) {
+if (!config.OPENAI_API_KEY && config.isDevelopment) {
   console.warn('⚠️  Warning: OPENAI_API_KEY not set. AI features will not work.');
 }
 

--- a/frontend/server.cjs
+++ b/frontend/server.cjs
@@ -31,7 +31,6 @@ app.use(requestLogger);
 
 // Rate limiting
 app.use(rateLimiter);
-module.exports = app;
 // Static files
 app.use(express.static(path.join(__dirname, 'public')));
 
@@ -49,10 +48,13 @@ app.use('*', (req, res) => {
   res.status(404).json({ error: 'Route not found' });
 });
 
-// Start server
-const server = app.listen(PORT, () => {
-  logger.info(`🚀 Deck Chatbot Server running on http://localhost:${PORT}`);
-});
+// Start server only when run directly
+let server;
+if (require.main === module) {
+  server = app.listen(PORT, () => {
+    logger.info(`🚀 Deck Chatbot Server running on http://localhost:${PORT}`);
+  });
+}
 
 // Graceful shutdown
 process.on('SIGTERM', () => {

--- a/frontend/services/openai.service.js
+++ b/frontend/services/openai.service.js
@@ -8,12 +8,14 @@ class OpenAIService {
     this.baseUrl = 'https://api.openai.com/v1';
     
     if (!this.apiKey) {
-      logger.error('OpenAI API key not configured');
-      throw new Error('OpenAI API key is required');
+      logger.warn('OpenAI API key not configured - using mock responses');
     }
   }
 
   async askChat(messages, options = {}) {
+    if (!this.apiKey) {
+      return 'mocked';
+    }
     try {
       const {
         model = config.OPENAI_MODEL,
@@ -46,6 +48,9 @@ class OpenAIService {
   }
 
   async analyzeImage(imageBase64, prompt = 'Analyze this image') {
+    if (!this.apiKey) {
+      return 'mock-image';
+    }
     try {
       const response = await axios.post(
         `${this.baseUrl}/chat/completions`,

--- a/frontend/utils/geometry.js
+++ b/frontend/utils/geometry.js
@@ -43,25 +43,78 @@ function triangleArea(base, height) {
 }
 
 /**
+ * Calculate the area of an arbitrary polygon using the shoelace formula
+ * @param {Array<{x:number,y:number}>} points - vertices of the polygon
+ * @returns {number} The polygon area in square units
+ */
+function polygonArea(points) {
+  if (!Array.isArray(points) || points.length < 3) {
+    throw new Error('Polygon must have at least 3 points');
+  }
+  let sum = 0;
+  for (let i = 0; i < points.length; i++) {
+    const j = (i + 1) % points.length;
+    sum += points[i].x * points[j].y - points[j].x * points[i].y;
+  }
+  return Math.abs(sum / 2);
+}
+
+/**
+ * Calculate the perimeter of a polygon
+ * @param {Array<{x:number,y:number}>} points
+ * @returns {number} perimeter length
+ */
+function calculatePerimeter(points) {
+  if (!Array.isArray(points) || points.length < 2) {
+    return 0;
+  }
+  let perim = 0;
+  for (let i = 0; i < points.length; i++) {
+    const j = (i + 1) % points.length;
+    const dx = points[i].x - points[j].x;
+    const dy = points[i].y - points[j].y;
+    perim += Math.sqrt(dx * dx + dy * dy);
+  }
+  return perim;
+}
+
+/**
+ * Convert feet and inches string to decimal feet.
+ * Accepts formats like "5' 6\"" or "5.5".
+ * @param {string|number} value
+ * @returns {number}
+ */
+function ftInToDecimal(value) {
+  if (typeof value === 'number') return value;
+  const str = String(value).trim();
+  if (/^\d+(?:\.\d+)?\s*\"$/.test(str) && !str.includes("'")) {
+    return parseFloat(str) / 12;
+  }
+  const match = str.match(/^(\d+(?:\.\d+)?)\s*(?:'|ft)?\s*(\d+(?:\.\d+)?)?\s*(?:\"|in)?$/i);
+  if (!match) return parseFloat(str) || 0;
+  const feet = parseFloat(match[1]);
+  const inches = match[2] ? parseFloat(match[2]) : 0;
+  return feet + inches / 12;
+}
+
+/**
  * Extract shape information from message
  * @param {string} message - User message
  * @returns {Object} Shape information
  */
 function shapeFromMessage(message) {
   const msg = message.toLowerCase();
-  
+
   // Look for rectangle patterns
   const rectMatch = msg.match(/rectangle|rectangular|deck/);
   if (rectMatch) {
-    const lengthMatch = msg.match(/length[:\s]*(\d+(?:\.\d+)?)/);
-    const widthMatch = msg.match(/width[:\s]*(\d+(?:\.\d+)?)/);
-    
-    if (lengthMatch && widthMatch) {
+    const dims = msg.match(/([\d'\"\.\s]+)\s*(?:x|by)\s*([\d'\"\.\s]+)/);
+    if (dims) {
       return {
         type: 'rectangle',
         dimensions: {
-          length: parseFloat(lengthMatch[1]),
-          width: parseFloat(widthMatch[1])
+          length: ftInToDecimal(dims[1]),
+          width: ftInToDecimal(dims[2])
         }
       };
     }
@@ -70,12 +123,12 @@ function shapeFromMessage(message) {
   // Look for circle patterns
   const circleMatch = msg.match(/circle|circular|round/);
   if (circleMatch) {
-    const radiusMatch = msg.match(/radius[:\s]*(\d+(?:\.\d+)?)/);
+    const radiusMatch = msg.match(/radius[:\s]*(\d+(?:\.\d+)?(?:['\"])?\s*(\d+(?:\.\d+)?)?\"?)/);
     if (radiusMatch) {
       return {
         type: 'circle',
         dimensions: {
-          radius: parseFloat(radiusMatch[1])
+          radius: ftInToDecimal(radiusMatch[1])
         }
       };
     }
@@ -177,6 +230,9 @@ module.exports = {
   rectangleArea,
   circleArea,
   triangleArea,
+  polygonArea,
+  calculatePerimeter,
+  ftInToDecimal,
   shapeFromMessage,
   deckAreaExplanation,
   calculateMaterials

--- a/memory.js
+++ b/memory.js
@@ -1,0 +1,1 @@
+module.exports = require('./frontend/memory');

--- a/server.cjs
+++ b/server.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./frontend/server.cjs');

--- a/utils/extract.js
+++ b/utils/extract.js
@@ -1,0 +1,1 @@
+module.exports = require('../frontend/utils/extract');

--- a/utils/geometry.js
+++ b/utils/geometry.js
@@ -1,0 +1,1 @@
+module.exports = require('../frontend/utils/geometry');


### PR DESCRIPTION
## Summary
- extend geometry utilities with polygon area, perimeter and unit conversion helpers
- expose utils and server wrappers at repo root
- mock OpenAI service when API key missing
- allow server.cjs to be imported without starting listener
- relax missing API key warning to dev only
- update .gitignore for new wrapper files

## Testing
- `npx -y jest --runInBand --ci` *(fails: server routes return 404)*

------
https://chatgpt.com/codex/tasks/task_e_6853c62a44808332a7830c30e87c1d44