### PR TITLE
Add l-shape and octagon support

### DIFF
--- a/__tests__/shape.test.js
+++ b/__tests__/shape.test.js
@@ -56,6 +56,18 @@ describe('geometry utilities', () => {
     const msg = 'circle radius 18\"';
     expect(shapeFromMessage(msg)).toEqual({ type: 'circle', dimensions: { radius: 1.5 } });
   });
+  test("shapeFromMessage parses l-shape", () => {
+    const msg = "l-shape 10x20 plus 5x15";
+    expect(shapeFromMessage(msg)).toEqual({
+      type: "lshape",
+      dimensions: { length1: 10, width1: 20, length2: 5, width2: 15 }
+    });
+  });
+
+  test("shapeFromMessage parses octagon", () => {
+    const msg = "octagon side 8";
+    expect(shapeFromMessage(msg)).toEqual({ type: "octagon", dimensions: { side: 8 } });
+  });
 
   test('shapeFromMessage handles invalid input', () => {
     expect(shapeFromMessage('gibberish')).toBeNull();

--- a/frontend/utils/geometry.js
+++ b/frontend/utils/geometry.js
@@ -2,6 +2,7 @@
 /**
  * Geometry utility functions for deck calculations
  */
+const { extractNumbers } = require('./extract');
 
 /**
  * Calculate rectangle area
@@ -129,6 +130,34 @@ function shapeFromMessage(message) {
         dimensions: {
           radius: ftInToDecimal(radiusMatch[1])
         }
+      };
+    }
+  }
+
+  // Look for L-shape patterns
+  if (/l[- ]?shape/.test(msg)) {
+    const nums = extractNumbers(msg);
+    if (nums.length >= 4) {
+      const [l1, w1, l2, w2] = nums;
+      return {
+        type: 'lshape',
+        dimensions: {
+          length1: l1,
+          width1: w1,
+          length2: l2,
+          width2: w2
+        }
+      };
+    }
+  }
+
+  // Look for octagon patterns
+  if (/octagon/.test(msg)) {
+    const nums = extractNumbers(msg);
+    if (nums.length >= 1) {
+      return {
+        type: 'octagon',
+        dimensions: { side: nums[0] }
       };
     }
   }


### PR DESCRIPTION
### **User description**
## Summary
- extend geometry parsing with l-shape and octagon detection
- update shape tests for new cases

## Testing
- `npx --yes jest` *(fails: Cannot find module 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6853d9c537688332abb2c35e06f568d5


___

### **PR Type**
Enhancement


___

### **Description**
• Add L-shape and octagon geometry parsing support
• Extend shape detection with new pattern matching
• Add comprehensive test coverage for new shapes
• Import extractNumbers utility for number parsing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shape.test.js</strong><dd><code>Add L-shape and octagon test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

__tests__/shape.test.js

• Add test case for L-shape parsing with dimensions<br> • Add test case <br>for octagon parsing with side length<br> • Verify correct shape object <br>structure and values


</details>


  </td>
  <td><a href="https://github.com/alentwotime/deckchatbot-monorepo/pull/25/files#diff-dbeb8b1053c9b170a2ea0c5f219490faae2be9afe0d336ce0126ced682d60a64">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>geometry.js</strong><dd><code>Implement L-shape and octagon parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/utils/geometry.js

• Import extractNumbers utility for number extraction<br> • Add L-shape <br>pattern matching and parsing logic<br> • Add octagon pattern matching and <br>parsing logic<br> • Extract dimensions from message text using regex


</details>


  </td>
  <td><a href="https://github.com/alentwotime/deckchatbot-monorepo/pull/25/files#diff-7e78e426e82b131361ff75c9232b8726e7b38c59881b0c1f0289970934b94806">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>