### PR TITLE
Improve azure setup script and backend error handling

### DIFF
--- a/azure_setup.sh
+++ b/azure_setup.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 # Required environment variables
 : "${AZURE_RG?Need AZURE_RG}"       # Resource group
 : "${ACR_NAME?Need ACR_NAME}"       # Azure Container Registry name
-: "${LOCATION?Need LOCATION}"       # Deployment location, e.g. "Central US"
+# Default location to Central US if not provided
+LOCATION="${LOCATION:-Central US}"
 
 BACKEND_APP=deckchatbot-backend-app
 FRONTEND_APP=deckchatbot-frontend-app
@@ -21,6 +22,12 @@ fi
 if ! az account show >/dev/null 2>&1; then
   echo "Please run 'az login' before executing this script." >&2
   exit 1
+fi
+
+# Create resource group if it doesn't exist
+if ! az group show --name "$AZURE_RG" >/dev/null 2>&1; then
+  echo "Creating resource group $AZURE_RG in $LOCATION"
+  az group create --name "$AZURE_RG" --location "$LOCATION" >/dev/null
 fi
 
 # Build and push Docker images to ACR

--- a/backend/backend-ai/ai-service/llava_handler.py
+++ b/backend/backend-ai/ai-service/llava_handler.py
@@ -1,8 +1,11 @@
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 import io
 
 def process_image(image_bytes):
-    # Placeholder logic – this is where LLaVA or OCR will go
-    image = Image.open(io.BytesIO(image_bytes))
+    """Process an uploaded image and return a simple description."""
+    try:
+        image = Image.open(io.BytesIO(image_bytes))
+    except UnidentifiedImageError:
+        raise
     width, height = image.size
     return f"Received image of size {width}x{height}"

--- a/backend/backend-ai/ai-service/main.py
+++ b/backend/backend-ai/ai-service/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI, UploadFile, File
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from PIL import UnidentifiedImageError
 from llava_handler import process_image
 
 app = FastAPI()
@@ -9,6 +10,11 @@ def root():
 
 @app.post("/analyze-image/")
 async def analyze_image(file: UploadFile = File(...)):
-    contents = await file.read()
-    result = process_image(contents)
-    return {"result": result}
+    try:
+        contents = await file.read()
+        result = process_image(contents)
+        return {"result": result}
+    except UnidentifiedImageError:
+        raise HTTPException(status_code=400, detail="Invalid image file")
+    except Exception:
+        raise HTTPException(status_code=500, detail="Image processing failed")


### PR DESCRIPTION
### **User description**
## Summary
- add default LOCATION to azure setup script and create the resource group if missing
- improve backend image endpoint error handling

## Testing
- `python -m py_compile backend/backend-ai/ai-service/main.py backend/backend-ai/ai-service/llava_handler.py`
- `npx --yes jest` *(fails: Cannot find module 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6854da317fd083329bd7b423afe4d98f


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
• Improve Azure deployment script with default location and resource group creation
• Add robust error handling for image processing endpoints
• Enhance backend service reliability with proper exception handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azure_setup.sh</strong><dd><code>Improve deployment automation with defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

azure_setup.sh

• Set default LOCATION to "Central US" if not provided<br> • Add automatic <br>resource group creation if missing<br> • Remove requirement for LOCATION <br>environment variable


</details>


  </td>
  <td><a href="https://github.com/alentwotime/deckchatbot-monorepo/pull/26/files#diff-bb36caad134756aba8281327e6a91af0323527a8d75ed8409872bdc1325c9e9c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llava_handler.py</strong><dd><code>Add image processing error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/backend-ai/ai-service/llava_handler.py

• Import <code>UnidentifiedImageError</code> for proper error handling<br> • Add <br>try-catch block around image opening<br> • Add function docstring for <br>clarity


</details>


  </td>
  <td><a href="https://github.com/alentwotime/deckchatbot-monorepo/pull/26/files#diff-b01d3ee70c6dc84b3d4bfc889d3dd4728f1616da1d1e270feeccae7dda157f25">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Enhance API endpoint error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/backend-ai/ai-service/main.py

• Import <code>HTTPException</code> and <code>UnidentifiedImageError</code><br> • Wrap image <br>analysis endpoint in try-catch blocks<br> • Return proper HTTP status <br>codes for different error types


</details>


  </td>
  <td><a href="https://github.com/alentwotime/deckchatbot-monorepo/pull/26/files#diff-f459bb00560e461e9da3dfb9f6a067c94b391cdfe723505200c815a02f12f015">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>