### PR TITLE
Update Docker environment

### DIFF
--- a/backend/backend-ai/.dockerignore
+++ b/backend/backend-ai/.dockerignore
@@ -1,9 +1,12 @@
-# Ignore Python cache and dev files
-__pycache__/
+node_modules
+__pycache__
 *.pyc
 *.pyo
 .git
-*.md
-Dockerfile*
-.dockerignore
+.gitignore
+.vscode
+.env
+.DS_Store
+*.log
 tests/
+docs/

--- a/backend/backend-ai/Dockerfile
+++ b/backend/backend-ai/Dockerfile
@@ -1,15 +1,20 @@
-# Stage 1 - build dependencies and export requirements
-FROM python:3.10-slim AS builder
-WORKDIR /app
-RUN pip install --no-cache-dir poetry
-COPY pyproject.toml poetry.lock ./
-RUN poetry export --without-hashes --only main -f requirements.txt -o requirements.txt
-
-# Stage 2 - runtime image
+# Use official Python 3.10 slim image
 FROM python:3.10-slim
+
+# Set working directory
 WORKDIR /app
-COPY --from=builder /app/requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy dependency files
+COPY poetry.lock pyproject.toml ./
+
+# Install Poetry and dependencies (no root)
+RUN pip install poetry && poetry config virtualenvs.create false && poetry install --no-root
+
+# Copy backend source code
 COPY . .
+
+# Expose backend port
 EXPOSE 8000
-CMD ["uvicorn", "API.api:app", "--host", "0.0.0.0", "--port", "8000"]
+
+# Run the backend API with uvicorn
+CMD ["uvicorn", "API.api:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,21 @@
-version: "3.9"
+version: '3.9'
+
 services:
   backend:
     build: ./backend/backend-ai
     ports:
       - "8000:8000"
+    environment:
+      # Add backend env vars here, or better, use env_file:
+      # - ENV_VAR=value
+    volumes:
+      - ./backend/backend-ai:/app  # Optional: live code reload
+
   frontend:
     build: ./frontend
     ports:
       - "3000:3000"
     environment:
-      API_KEY: ${API_KEY:-revamp123secure}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-changeme}
-    depends_on:
-      - backend
-
+      - REACT_APP_API_URL=http://localhost:8000
+    volumes:
+      - ./frontend:/app             # Optional: live reload

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,12 +1,12 @@
-# Ignore node_modules and logs
 node_modules
-npm-debug.log
-Dockerfile*
-.dockerignore
+__pycache__
+*.pyc
+*.pyo
 .git
 .gitignore
-**/*.md
-logs
-uploads
-coverage
-__tests__
+.vscode
+.env
+.DS_Store
+*.log
+tests/
+docs/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,14 +1,26 @@
-# Stage 1 - install dependencies
-FROM node:18-alpine AS builder
+# Use Node 18 Alpine base image
+FROM node:18-alpine
+
+# Set working directory
 WORKDIR /app
-COPY package*.json ./
-RUN npm ci --omit=dev
+
+# Copy package files
+COPY package.json package-lock.json* ./
+
+# Install dependencies
+RUN npm install
+
+# Copy all frontend files
 COPY . .
 
-# Stage 2 - runtime
-FROM node:18-alpine
-WORKDIR /app
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app .
+# Build React/Vite frontend
+RUN npm run build
+
+# Use serve to serve production build
+RUN npm install -g serve
+
+# Expose port 3000
 EXPOSE 3000
-CMD ["node", "server.js"]
+
+# Start the frontend server
+CMD ["serve", "-s", "build", "-l", "3000"]


### PR DESCRIPTION
## Summary
- configure backend Dockerfile for poetry-based install
- update frontend Dockerfile to build static files with serve
- set up live-reload volumes in docker-compose
- use unified `.dockerignore` patterns for frontend and backend

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854e61345a083328a1d7c465ab6d487