### PR TITLE
Add Dockerfile for FastAPI app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use official Python 3.11 slim image
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source code
+COPY . .
+
+# Expose port 11434
+EXPOSE 11434
+
+# Start FastAPI app with uvicorn on container start
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "11434", "--reload"]


### PR DESCRIPTION
## Summary
- create a Dockerfile using Python 3.11-slim
- install dependencies, copy source, expose port 11434
- run FastAPI app with uvicorn on container start

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `npm test` at repo root *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6854fa9260f48332b14798f7cc09c16d

## Summary by Sourcery

Add a Dockerfile to containerize the FastAPI application and run it with uvicorn on port 11434

Build:
- Add a Dockerfile based on Python 3.11-slim to containerize the FastAPI app
- Install dependencies from requirements.txt and copy the application source into the image
- Expose port 11434 and configure uvicorn as the container startup command