### PR TITLE
Add dev dirs to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,5 @@ __pycache__
 .vscode
 .idea
 *.md
+node_modules/
+.venv/


### PR DESCRIPTION
## Summary
- ignore `node_modules/` and `.venv/` in Docker builds

## Testing
- `npm install`
- `npm test`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685607d610288332b3774d6c1fa242bc