### PR TITLE
Fix docker build paths and remove unused ai-service copy

### DIFF
--- a/apps/app1/Dockerfile
+++ b/apps/app1/Dockerfile
@@ -19,7 +19,6 @@ RUN pip install --no-cache-dir /wheels/* && rm -rf /wheels
 
 # Copy code
 COPY API /app/API
-COPY ai-service /app/ai-service
 COPY requirements.txt .
 
 # Security: Use a non-root user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
-version: '3.8'
-
 services:
   backend:
     build:
       context: ./backend
-      dockerfile: ./backend/Dockerfile
+      dockerfile: Dockerfile
     environment:
       - PORT=8000
     ports:
@@ -14,7 +12,7 @@ services:
   frontend:
     build:
       context: ./frontend
-      dockerfile: ./frontend/Dockerfile
+      dockerfile: Dockerfile
     ports:
       - "3000:3000"
     volumes:
@@ -27,7 +25,7 @@ services:
   app1:
     build:
       context: ./apps/app1
-      dockerfile: ./apps/app1/Dockerfile
+      dockerfile: Dockerfile
     ports:
       - "8010:8000"
     restart: unless-stopped
@@ -35,7 +33,7 @@ services:
   app2:
     build:
       context: ./apps/app2
-      dockerfile: ./apps/app2/Dockerfile
+      dockerfile: Dockerfile
     ports:
       - "8020:8000"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- fix context dockerfile path resolution in `docker-compose.yml`
- remove reference to missing `ai-service` directory from app1 Dockerfile

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68561b7322e48332a55581140616bd74