### PR TITLE
Add monorepo lint/format script

### DIFF
--- a/scripts/check-code.ps1
+++ b/scripts/check-code.ps1
@@ -1,0 +1,61 @@
+param(
+    [switch]$fix
+)
+
+$ErrorActionPreference = 'Continue'
+
+$repoRoot = Split-Path $PSScriptRoot -Parent
+Set-Location $repoRoot
+
+$timestamp = Get-Date -Format "yyyy-MM-dd_HHmm"
+$logsDir = Join-Path $repoRoot 'logs'
+if (!(Test-Path $logsDir)) { New-Item -Path $logsDir -ItemType Directory | Out-Null }
+
+$pyLog = Join-Path $logsDir "python-lint-$timestamp.log"
+$jsLog = Join-Path $logsDir "js-lint-$timestamp.log"
+
+Write-Host "Running Python lint and format..." -ForegroundColor Cyan
+
+# Python linting and formatting
+$pySuccess = $true
+
+docker-compose run --rm backend flake8 2>&1 | Tee-Object -FilePath $pyLog
+if ($LASTEXITCODE -ne 0) { $pySuccess = $false }
+
+docker-compose run --rm backend black . 2>&1 | Tee-Object -FilePath $pyLog -Append
+if ($LASTEXITCODE -ne 0) { $pySuccess = $false }
+
+docker-compose run --rm backend isort . 2>&1 | Tee-Object -FilePath $pyLog -Append
+if ($LASTEXITCODE -ne 0) { $pySuccess = $false }
+
+if ($pySuccess) {
+    Write-Host "Python ✅ Passed" -ForegroundColor Green
+} else {
+    Write-Host "Python ❌ Errors Found" -ForegroundColor Red
+}
+
+# JavaScript/TypeScript linting
+Write-Host "Running JavaScript/TypeScript lint..." -ForegroundColor Cyan
+$jsSuccess = $true
+
+$eslintCmd = 'eslint .'
+if ($fix) { $eslintCmd = 'eslint . --fix' }
+
+# run inside frontend container
+# Use bash -c to pass full command
+
+docker-compose run --rm frontend sh -c $eslintCmd 2>&1 | Tee-Object -FilePath $jsLog
+if ($LASTEXITCODE -ne 0) { $jsSuccess = $false }
+
+if ($jsSuccess) {
+    Write-Host "JavaScript ✅ Passed" -ForegroundColor Green
+} else {
+    Write-Host "JavaScript ❌ Errors Found" -ForegroundColor Red
+}
+
+if ($pySuccess -and $jsSuccess) {
+    exit 0
+} else {
+    exit 1
+}
+


### PR DESCRIPTION
## Summary
- add PowerShell script for linting/formatting Python and JS code

## Testing
- `docker-compose run --rm backend flake8` *(fails: command not found)*
- `docker-compose run --rm frontend eslint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563fcd7fa08332a62fa684176379d4

## Summary by Sourcery

Add a cross-language lint and format script to the monorepo for consistent Python and JavaScript code quality checks

New Features:
- Introduce `scripts/check-code.ps1` to orchestrate linting and formatting across backend and frontend containers
- Add an optional `--fix` switch to automatically apply ESLint fixes

Enhancements:
- Run flake8, black, and isort for Python in the backend container and eslint for JavaScript/TypeScript in the frontend container
- Record timestamped outputs to a `logs` directory for both Python and JS runs
- Display colored success or error summaries and return a non-zero exit code when issues are detected