### PR TITLE
Fix Poetry paths for AI service

### DIFF
--- a/apps/app2/pyproject.toml
+++ b/apps/app2/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Your Name <you@example.com>"]
 [tool.poetry.dependencies]
 python = "^3.11"
 requests = "^2.26"
-lib1 = { path = "../../libs/lib1", develop = true }
+lib1 = { path = "../../backend/backend-ai/ai-service", develop = true }
 
 [build-system]
 requires = ["poetry-core"]

--- a/backend/backend-ai/pyproject.toml
+++ b/backend/backend-ai/pyproject.toml
@@ -10,7 +10,7 @@ fastapi = "^0.115.0"
 uvicorn = "^0.34.0"
 httpx = "^0.27.0"
 python-multipart = "^0.0.6"
-lib1 = { path = "../../libs/lib1", develop = true }
+lib1 = { path = "./ai-service", develop = true }
 
 [build-system]
 requires = ["poetry-core"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -27,6 +27,7 @@ files = [
 [package.dependencies]
 idna = ">=2.8"
 sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
@@ -46,25 +47,26 @@ develop = true
 [package.dependencies]
 fastapi = "^0.115.0"
 httpx = "^0.27.0"
-lib1 = {path = "../../libs/lib1", develop = true}
+lib1 = {path = "ai-service", develop = true}
+python-multipart = "^0.0.6"
 uvicorn = "^0.34.0"
 
 [package.source]
 type = "directory"
-url = "apps/app1"
+url = "backend/backend-ai"
 
 [[package]]
 name = "app2"
 version = "0.1.0"
 description = "Application 2 for DeckChatBot"
 optional = false
-python-versions = "^3.13"
+python-versions = "^3.11"
 groups = ["app"]
 files = []
 develop = true
 
 [package.dependencies]
-lib1 = {path = "../../libs/lib1", develop = true}
+lib1 = {path = "../../backend/backend-ai/ai-service", develop = true}
 requests = "^2.26"
 
 [package.source]
@@ -373,14 +375,14 @@ uvicorn = "^0.34.0"
 
 [package.source]
 type = "directory"
-url = "libs/lib1"
+url = "backend/backend-ai/ai-service"
 
 [[package]]
 name = "lib2"
 version = "0.1.0"
 description = "Library 2 for DeckChatBot"
 optional = false
-python-versions = "^3.13"
+python-versions = "^3.11"
 groups = ["lib"]
 files = []
 develop = true
@@ -849,5 +851,5 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.13"
-content-hash = "2fc7e6b1b5ad0f0564fc0aabdc7b2f6f5e3e5163c9002da758e3d314956a747d"
+python-versions = "^3.11"
+content-hash = "3ef8557c63c36f2200f28ef5335038e7dcbd42f87da383d934293eadfb3df429"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,13 @@ requests = "^2.26"
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"
 
+
 [tool.poetry.group.app.dependencies]
-app1 = { path = "apps/app1", develop = true }
+app1 = { path = "backend/backend-ai", develop = true }
 app2 = { path = "apps/app2", develop = true }
 
 [tool.poetry.group.lib.dependencies]
-lib1 = { path = "libs/lib1", develop = true }
+lib1 = { path = "backend/backend-ai/ai-service", develop = true }
 lib2 = { path = "libs/lib2", develop = true }
 
 [tool.poetry-monorepo-dependency-plugin]


### PR DESCRIPTION
## Summary
- point monorepo dependencies to backend path
- fix backend references to ai-service
- fix app2 references to ai-service
- regenerate Poetry lock file

## Testing
- `poetry lock`
- ❌ `docker-compose run backend pytest -q` *(command failed: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568862146c8332aa2b738f1b4ba317