### PR TITLE
Fix ai-service Dockerfile build context

### DIFF
--- a/backend/backend-ai/ai-service/Dockerfile
+++ b/backend/backend-ai/ai-service/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install Poetry and project dependencies
-COPY pyproject.toml poetry.lock ./
+COPY backend/backend-ai/ai-service/pyproject.toml backend/backend-ai/ai-service/poetry.lock ./
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl build-essential && \
     curl -sSL https://install.python-poetry.org | python3 - && \
@@ -17,7 +17,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy application source code
-COPY . .
+COPY backend/backend-ai/ai-service /app
 
 # Expose port
 EXPOSE 11434


### PR DESCRIPTION
## Summary
- copy the ai-service `pyproject.toml` and `poetry.lock` when building
- only copy the ai-service directory into the Docker image

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68572e6749a0833280f6fd6059024c4a

## Summary by Sourcery

Fix Dockerfile for ai-service to correctly include project configuration files and limit the build context.

Bug Fixes:
- Correctly copy pyproject.toml and poetry.lock from the ai-service directory in the Dockerfile.
- Restrict Docker build context to only the ai-service directory instead of the entire project.

Enhancements:
- Reduce Docker image build context by only copying the ai-service folder.