### PR TITLE
Fix webpack build and add UI sections

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "express": "^5.1.0",
     "ollama": "^0.5.16",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "three": "^0.164.1"
   },
   "devDependencies": {
     "@babel/core": "^7.22.5",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,35 @@
+.app {
+  padding: 20px;
+  font-family: Arial, sans-serif;
+}
+.tabs button {
+  margin-right: 8px;
+}
+.tabs .active {
+  font-weight: bold;
+}
+.chat-section {
+  display: flex;
+  flex-direction: column;
+  height: 400px;
+}
+.chat-log {
+  flex: 1;
+  border: 1px solid #ccc;
+  padding: 10px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+.msg {
+  margin: 4px 0;
+}
+.msg.user {
+  text-align: right;
+}
+.chat-input {
+  display: flex;
+}
+.chat-input input {
+  flex: 1;
+  padding: 4px;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,63 +1,129 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+import './App.css';
 
-// Dynamically load all files inside ../routes except index.js
-const routeContext = require.context(
-  "../routes",
-  false,
-  /^(?!\.\/index).*\.js$/,
-);
+const apiBase = '';
 
-const routes = routeContext.keys().reduce((acc, file) => {
-  const name = file.replace("./", "").replace(".js", "");
-  const mod = routeContext(file);
-  const Component = mod.default
-    ? mod.default
-    : () => <div>Component Not Ready</div>;
-  acc[name] = Component;
-  return acc;
-}, {});
+const ChatSection = () => {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const logRef = useRef(null);
 
-const tabs = Object.keys(routes);
+  const send = async () => {
+    if (!input.trim()) return;
+    const userMessage = { sender: 'user', text: input };
+    setMessages((m) => [...m, userMessage, { sender: 'bot', text: '...' }]);
+    setInput('');
+    try {
+      const res = await fetch(`${apiBase}/chatbot`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: input }),
+      });
+      const data = await res.json();
+      setMessages((m) => m.slice(0, -1).concat({ sender: 'bot', text: data.response || 'No response' }));
+    } catch (err) {
+      setMessages((m) => m.slice(0, -1).concat({ sender: 'bot', text: 'Error' }));
+    }
+  };
 
-const Home = () => <div>Welcome to DeckChatbot!</div>;
-
-const App = () => {
-  const [selectedTab, setSelectedTab] = useState("");
-
-  const SelectedComponent = selectedTab ? routes[selectedTab] : Home;
+  useEffect(() => {
+    logRef.current?.scrollTo(0, logRef.current.scrollHeight);
+  }, [messages]);
 
   return (
-    <div style={{ padding: 20 }}>
-      <h1>DeckChatbot</h1>
-      <nav
-        style={{
-          display: "flex",
-          gap: 8,
-          borderBottom: "1px solid #ccc",
-          marginBottom: 20,
-        }}
-      >
-        {tabs.map((tab) => (
-          <button
-            key={tab}
-            onClick={() => setSelectedTab(tab)}
-            style={{
-              background: "none",
-              border: "none",
-              padding: "6px 12px",
-              borderBottom:
-                selectedTab === tab
-                  ? "2px solid #000"
-                  : "2px solid transparent",
-              cursor: "pointer",
-            }}
-          >
-            {tab}
-          </button>
+    <div className="chat-section">
+      <div className="chat-log" ref={logRef}>
+        {messages.map((m, i) => (
+          <div key={i} className={`msg ${m.sender}`}>{m.text}</div>
         ))}
+      </div>
+      <div className="chat-input">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message"
+        />
+        <button onClick={send}>Send</button>
+      </div>
+    </div>
+  );
+};
+
+const DigitalizeSection = () => {
+  const [file, setFile] = useState(null);
+  const [svg, setSvg] = useState('');
+  const upload = async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('image', file);
+    try {
+      const res = await fetch(`${apiBase}/digitalize-drawing`, {
+        method: 'POST',
+        body: form,
+      });
+      if (res.ok) {
+        const text = await res.text();
+        setSvg(text);
+      }
+    } catch (err) {
+      setSvg('Error');
+    }
+  };
+  return (
+    <div>
+      <input type="file" onChange={(e) => setFile(e.target.files[0])} />
+      <button onClick={upload}>Digitalize</button>
+      <div dangerouslySetInnerHTML={{ __html: svg }} />
+    </div>
+  );
+};
+
+const ModelSection = () => {
+  const mountRef = useRef(null);
+  useEffect(() => {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, mountRef.current.clientWidth / 400, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(mountRef.current.clientWidth, 400);
+    mountRef.current.appendChild(renderer.domElement);
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshNormalMaterial();
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+    camera.position.z = 2;
+    const controls = new OrbitControls(camera, renderer.domElement);
+    const animate = () => {
+      requestAnimationFrame(animate);
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    animate();
+    return () => {
+      renderer.dispose();
+      mountRef.current.innerHTML = '';
+    };
+  }, []);
+  return <div ref={mountRef} style={{ width: '100%', height: 400 }} />;
+};
+
+const App = () => {
+  const [tab, setTab] = useState('chat');
+  return (
+    <div className="app">
+      <h1>DeckChatbot</h1>
+      <nav className="tabs">
+        <button onClick={() => setTab('chat')} className={tab === 'chat' ? 'active' : ''}>Chat</button>
+        <button onClick={() => setTab('digitalize')} className={tab === 'digitalize' ? 'active' : ''}>Digitalize Drawing</button>
+        <button onClick={() => setTab('model')} className={tab === 'model' ? 'active' : ''}>3D Model</button>
       </nav>
-      <div style={{ marginTop: 20 }}>
-        <SelectedComponent />
+      <div className="tab-content">
+        {tab === 'chat' && <ChatSection />}
+        {tab === 'digitalize' && <DigitalizeSection />}
+        {tab === 'model' && <ModelSection />}
       </div>
     </div>
   );

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import './App.css';
 
 // Get the root DOM element
 const container = document.getElementById('root');

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -5,10 +5,17 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 module.exports = {
   entry: './src/index.js',
   output: {
-    filename: 'bundle.js',
+    filename: '[name].[contenthash].js',
+    chunkFilename: '[name].[contenthash].chunk.js',
     path: path.resolve(__dirname, 'dist'),
     publicPath: 'auto',
     clean: true,
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
+    runtimeChunk: 'single',
   },
   mode: 'production',
   devtool: 'source-map',


### PR DESCRIPTION
## Summary
- use dynamic hashed filenames in webpack output
- preserve splitChunks and runtimeChunk optimizations
- add Three.js dependency
- redesign App to include Chat, Digitalize Drawing and 3D Model tabs
- add simple styles for new app layout

## Testing
- `npm test` *(fails: jest not found)*
- `cd frontend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588c1fcd6c833293bf454e6f8ab7da