### PR TITLE
Fix Docker build issues

### DIFF
--- a/backend/backend-ai/Dockerfile
+++ b/backend/backend-ai/Dockerfile
@@ -5,8 +5,10 @@ FROM node:18-alpine AS builder
 
 WORKDIR /app
 
-# Optional: use custom registry
-COPY .npmrc ./ 
+# Optional: use custom registry if available
+# The build should not fail when `.npmrc` is missing, so we skip copying
+# it by default. Uncomment if a registry file is provided.
+# COPY .npmrc ./
 
 # Install deps and build
 COPY package*.json ./
@@ -20,8 +22,8 @@ FROM node:18-alpine
 
 WORKDIR /app
 
-# Optional: same registry config (optional)
-COPY .npmrc ./ 
+# Optional: same registry config (uncomment if `.npmrc` is present)
+# COPY .npmrc ./
 
 RUN npm install -g serve
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,5 +38,4 @@ services:
       - "11437:11434"
       - "3003:3000"
     command: npx serve -s dist
-      - "11437:11434"  
-      - "3004:3000"   
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- skip copying optional .npmrc in backend Dockerfile
- tidy docker-compose.yml service definition

## Testing
- `npm test --yes` *(fails: Cannot find module 'supertest')*
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e18d08288332b27a8bf3e2d08766