### PR TITLE
Fix service wiring and environment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+REACT_APP_API_URL=http://localhost:8000
+AI_SERVICE_URL=http://localhost:8000/analyze-image

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: build up down logs
+
+build:
+docker-compose build
+
+up:
+docker-compose up -d
+
+down:
+docker-compose down
+
+logs:
+docker-compose logs -f

--- a/backend/app2/.dockerignore
+++ b/backend/app2/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+*.pyc
+*.pyo
+*.log
+.env

--- a/backend/app2/main.py
+++ b/backend/app2/main.py
@@ -1,4 +1,5 @@
 import httpx
+import os
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -14,7 +15,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-AI_SERVICE_URL = "https://deckbot-ai-service.onrender.com/analyze-image"
+AI_SERVICE_URL = os.getenv("AI_SERVICE_URL", "http://ai-service:8000/analyze-image")
+
+@app.get("/")
+async def health():
+    return {"status": "ok"}
 
 @app.post("/analyze-image")
 async def proxy_to_ai_service(file: UploadFile = File(...)):

--- a/backend/backend-ai/ai-service/.dockerignore
+++ b/backend/backend-ai/ai-service/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+*.pyc
+*.pyo
+*.log
+.env

--- a/backend/backend-ai/ai-service/Dockerfile
+++ b/backend/backend-ai/ai-service/Dockerfile
@@ -22,6 +22,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 - && \
 # Copy the rest of your app
 COPY . /app
 
-EXPOSE 11434
+ENV PORT=8000
+EXPOSE ${PORT}
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "11434"]
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,7 @@ services:
       dockerfile: Dockerfile
     container_name: deckbot-ai-service
     ports:
-      - "8001:8000"    
-      - "11435:11434"  
-      - "3001:3000"   
+      - "8002:8000"
     volumes:
       - ./backend/backend-ai/ai-service:/app
     env_file:
@@ -18,11 +16,15 @@ services:
 
   backend:
     build:
-      context: ./backend/backend-ai
+      context: ./backend/app2
       dockerfile: Dockerfile
     container_name: deckbot-backend
+    ports:
+      - "8000:8000"
     volumes:
-      - ./backend/backend-ai:/app
+      - ./backend/app2:/app
+    environment:
+      - AI_SERVICE_URL=http://ai-service:8000/analyze-image
     env_file:
       - .env
     depends_on:
@@ -34,8 +36,10 @@ services:
       context: ./frontend
     container_name: deckchatbot-frontend
     ports:
-      - "8080:8000"
-      - "11437:11434"
-      - "3003:3000"
+      - "3000:3000"
     command: npx serve -s dist
+    environment:
+      - REACT_APP_API_URL=http://backend:8000
+    depends_on:
+      - backend
     restart: unless-stopped

--- a/frontend/src/components/DeckBuilderUI.tsx
+++ b/frontend/src/components/DeckBuilderUI.tsx
@@ -31,8 +31,9 @@ export default function DeckBuilderUI() {
     if (file) {
       const formData = new FormData();
       formData.append("file", file);
+      const API_URL = process.env.REACT_APP_API_URL || "";
       try {
-        await axios.post("/analyze-image", formData, {
+        await axios.post(`${API_URL}/analyze-image`, formData, {
           headers: { "Content-Type": "multipart/form-data" },
         });
         const url = URL.createObjectURL(file);
@@ -52,7 +53,8 @@ export default function DeckBuilderUI() {
     setNewMessage("");
 
     try {
-      const res = await axios.post("/chat", { message: newMessage });
+      const API_URL = process.env.REACT_APP_API_URL || "";
+      const res = await axios.post(`${API_URL}/chat`, { message: newMessage });
       const botReply = res.data.reply || "Okay!";
       setChatMessages((prev) => [...prev, { role: "bot", text: botReply }]);
     } catch (error) {

--- a/render.yaml
+++ b/render.yaml
@@ -15,15 +15,15 @@ services:
     name: deckbot-backend
     env: docker
     repo: https://github.com/alentwotime/deckchatbot-monorepo
-    dockerContext: ./backend/backend-ai
-    dockerfilePath: ./backend/backend-ai/Dockerfile
+    dockerContext: ./backend/app2
+    dockerfilePath: ./backend/app2/Dockerfile
     branch: main
     plan: free
     envVars:
       - key: PORT
-        value: 11434
+        value: 8000
       - key: AI_SERVICE_URL
-        value: https://deckbot-ai-service.onrender.com
+        value: http://ai-service:8000/analyze-image
 
   - type: web
     name: deckbot-ai-service


### PR DESCRIPTION
## Summary
- load API base URL from env in DeckBuilderUI
- proxy to AI service with env var in FastAPI backend
- expose backend and AI service ports via docker-compose
- add example environment file, Makefile, and dockerignore files
- update Render and Dockerfiles for consistent PORT handling

## Testing
- `npm test` *(fails: needs jest install)*
- `docker-compose run backend flake8` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e5d478948332928bbac51d5a7c42