### PR TITLE
Fix jest supertest missing and numeric skirting tests

### DIFF
--- a/__tests__/chatbot.test.js
+++ b/__tests__/chatbot.test.js
@@ -43,7 +43,7 @@ const memoryDb = path.join(__dirname, 'memory_test.sqlite');
 process.env.MEM_DB = memoryDb;
 
 const { app } = require('../server.cjs');
-const memory = require('../memory');
+const memory = require('../frontend/memory');
 
 beforeEach(() => {
   memory.clearMemory();

--- a/__tests__/measurements.test.js
+++ b/__tests__/measurements.test.js
@@ -56,7 +56,7 @@ const memoryDb = path.join(__dirname, 'memory_edge.sqlite');
 process.env.MEM_DB = memoryDb;
 
 const { app } = require('../server.cjs');
-const memory = require('../memory');
+const memory = require('../frontend/memory');
 
 beforeEach(() => {
   memory.clearMemory();

--- a/frontend/controllers/skirtingController.js
+++ b/frontend/controllers/skirtingController.js
@@ -37,13 +37,13 @@ function calculateSkirting(req, res) {
   // Validate parameter types
   if (
     (length != null && typeof length !== 'string') ||
-    (lengthFt != null && typeof lengthFt !== 'string') ||
+    (lengthFt != null && typeof lengthFt !== 'string' && typeof lengthFt !== 'number') ||
     (lengthIn != null && typeof lengthIn !== 'number') ||
     (width != null && typeof width !== 'string') ||
-    (widthFt != null && typeof widthFt !== 'string') ||
+    (widthFt != null && typeof widthFt !== 'string' && typeof widthFt !== 'number') ||
     (widthIn != null && typeof widthIn !== 'number') ||
     (height != null && typeof height !== 'string') ||
-    (heightFt != null && typeof heightFt !== 'string') ||
+    (heightFt != null && typeof heightFt !== 'string' && typeof heightFt !== 'number') ||
     (heightIn != null && typeof heightIn !== 'number') ||
     (typeof sides !== 'number' || ![3, 4].includes(sides)) ||
     (material == null || typeof material !== 'string')


### PR DESCRIPTION
## Summary
- fix path to memory module in tests
- relax skirting controller validation to allow numeric values
- adjust test setup to use correct memory module

## Testing
- `npm test`
- `docker-compose run backend flake8` *(fails: command not found)*
- `docker-compose run frontend eslint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f5871fd483329272e3bc65d770cb