### PR TITLE
Fix frontend Docker build by restoring index.html

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>DeckChatbot</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- recreate `public/index.html` using existing HTML file

## Testing
- `npm test` *(fails: jest not found)*
- `docker compose build` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68591658a47c8332b7f97eac3c520cba

## Summary by Sourcery

Bug Fixes:
- Recreate public/index.html for the frontend public folder to re-enable Docker build