### PR TITLE
Fix Docker build path deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # Install system deps
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl build-essential && \
+    apt-get install -y --no-install-recommends curl build-essential git && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Poetry
@@ -14,8 +14,12 @@ RUN curl -sSL https://install.python-poetry.org | python3 - && \
 
 # Set Poetry config + install dependencies
 COPY pyproject.toml poetry.lock ./
+COPY backend/backend-ai ./backend/backend-ai
+COPY backend/app2 ./backend/app2
+COPY backend/backend-ai/ai-service ./backend/backend-ai/ai-service
+COPY libs/lib2 ./libs/lib2
 RUN poetry config virtualenvs.create false && \
-    poetry install --no-root --no-dev
+    poetry install --no-root --without dev
 
 # Copy source files
 COPY . .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = ["Your Name <you@example.com>"]
 python = "^3.11"
 requests = "^2.26"
 
-[tool.poetry.dev-dependencies]
+
+[tool.poetry.group.dev.dependencies]
 pytest = "^6.2"
 
 


### PR DESCRIPTION
## Summary
- update Dockerfile to include path deps and remove deprecated Poetry option
- adjust dev dependencies section in `pyproject.toml`

## Testing
- `npm test`
- `flake8` *(fails: command not found)*
- `npx eslint .` *(fails: config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68591db5e44c83329a75fbbb7d55d87a

## Summary by Sourcery

Update Dockerfile to support project path dependencies and modernize Poetry configuration, and migrate dev-dependencies section in pyproject.toml to Poetry 1.2 group syntax

Enhancements:
- Include local path packages in the Docker build before dependency installation
- Switch Poetry install to use `--without dev` instead of the deprecated `--no-dev` flag

Build:
- Add git to system dependencies in the Dockerfile
- Copy backend and libs directories into the Docker image to resolve path dependencies

Chores:
- Migrate dev-dependencies section to `[tool.poetry.group.dev.dependencies]` syntax in pyproject.toml