### PR TITLE
Fix API base URL and add /chat route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-REACT_APP_API_URL=http://localhost:8000
+REACT_APP_API_BASE_URL=http://localhost:8000
 AI_SERVICE_URL=http://localhost:8000/analyze-image

--- a/backend/backend-ai/main.py
+++ b/backend/backend-ai/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
 
@@ -31,3 +32,18 @@ async def analyze_image(file: UploadFile = File(...)):
         "filename": file.filename,
         "size_bytes": len(contents)
     }
+
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str | None = None
+
+
+@app.post("/chat")
+async def chat_handler(req: ChatRequest):
+    """Simple echo-style chat endpoint."""
+
+    async def chat_stream():
+        yield f"You said: {req.message}"
+
+    return StreamingResponse(chat_stream(), media_type="text/plain")

--- a/bridge/base/frontend-deployment.yaml
+++ b/bridge/base/frontend-deployment.yaml
@@ -28,7 +28,7 @@ spec:
                   image: deckchatbot-monorepo-frontend
                   imagePullPolicy: IfNotPresent
                   env:
-                    - name: REACT_APP_API_URL
+                    - name: REACT_APP_API_BASE_URL
                       value: "http://backend:8000"
                   ports:
                     - name: frontend-3000

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -20,6 +20,6 @@ services:
       - ./frontend:/app
     command: npx serve -s dist  
     environment:
-      - REACT_APP_API_URL=http://backend:8000
+      - REACT_APP_API_BASE_URL=http://backend:8000
     depends_on:
       - backend

--- a/frontend/docs/Deckchatbot_Deployment_Guide.md
+++ b/frontend/docs/Deckchatbot_Deployment_Guide.md
@@ -165,7 +165,9 @@ Place this in `client/public/`.
 In your React app:
 
 ```js
-const API_BASE = "https://deckbot-backend.onrender.com";
+const API_BASE =
+  process.env.REACT_APP_API_BASE_URL ||
+  "https://deckchatbot-backend.onrender.com";
 axios.get(`${API_BASE}/api/ping`);
 ```
 

--- a/frontend/frontend-possible-content/app.js
+++ b/frontend/frontend-possible-content/app.js
@@ -1,4 +1,6 @@
-const API_BASE = 'https://deckchatbot-backend.onrender.com';
+const API_BASE =
+  process.env.REACT_APP_API_BASE_URL ||
+  'https://deckchatbot-backend.onrender.com';
 
 function App() {
   const [blueprint, setBlueprint] = React.useState(null);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 
-const API_BASE = 'https://deckchatbot-backend.onrender.com';
+const API_BASE = process.env.REACT_APP_API_BASE_URL ||
+  'https://deckchatbot-backend.onrender.com';
 
 function App() {
   const [blueprint, setBlueprint] = useState(null);

--- a/frontend/src/components/DeckBuilderUI.tsx
+++ b/frontend/src/components/DeckBuilderUI.tsx
@@ -31,7 +31,8 @@ export default function DeckBuilderUI() {
     if (file) {
       const formData = new FormData();
       formData.append("file", file);
-      const API_URL = process.env.REACT_APP_API_URL || "";
+      const API_URL =
+        process.env.REACT_APP_API_BASE_URL || "https://deckchatbot-backend.onrender.com";
       try {
         await axios.post(`${API_URL}/analyze-image`, formData, {
           headers: { "Content-Type": "multipart/form-data" },
@@ -53,7 +54,8 @@ export default function DeckBuilderUI() {
     setNewMessage("");
 
     try {
-      const API_URL = process.env.REACT_APP_API_URL || "";
+      const API_URL =
+        process.env.REACT_APP_API_BASE_URL || "https://deckchatbot-backend.onrender.com";
       const res = await axios.post(`${API_URL}/chat`, { message: newMessage });
       const botReply = res.data.reply || "Okay!";
       setChatMessages((prev) => [...prev, { role: "bot", text: botReply }]);

--- a/other/Deckchatbot_Deployment_Guide.md
+++ b/other/Deckchatbot_Deployment_Guide.md
@@ -165,7 +165,9 @@ Place this in `client/public/`.
 In your React app:
 
 ```js
-const API_BASE = "https://deckbot-backend.onrender.com";
+const API_BASE =
+  process.env.REACT_APP_API_BASE_URL ||
+  "https://deckchatbot-backend.onrender.com";
 axios.get(`${API_BASE}/api/ping`);
 ```
 


### PR DESCRIPTION
## Summary
- read API base URL from `REACT_APP_API_BASE_URL`
- update docs and docker-compose files with new env var
- add simple `/chat` route to FastAPI backend

## Testing
- `npm test` *(fails: Cannot find module 'supertest')*
- `docker-compose run backend flake8` *(fails: command not found)*
- `docker-compose run frontend eslint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859296020308332bbfed883cac1008a