### PR TITLE
Wire lib2 across backend services

### DIFF
--- a/backend/backend-ai/ai-service/pyproject.toml
+++ b/backend/backend-ai/ai-service/pyproject.toml
@@ -12,6 +12,7 @@ pillow = "^11.0.0"
 pytesseract = "^0.3.13"
 httpx = "^0.28.1"
 python-multipart = "^0.0.6"
+lib2 = { path = "../../../libs/lib2", develop = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.1"

--- a/backend/backend-ai/main.py
+++ b/backend/backend-ai/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
+from lib2 import my_helper
 
 app = FastAPI()
 
@@ -17,7 +18,7 @@ app.add_middleware(
 
 @app.get("/")
 def root():
-    return {"message": "AI service is running."}
+    return {"message": "AI service is running.", "helper": my_helper(2)}
 
 
 @app.post("/analyze-image")

--- a/backend/backend-ai/pyproject.toml
+++ b/backend/backend-ai/pyproject.toml
@@ -11,6 +11,7 @@ uvicorn = "^0.34.0"
 httpx = "^0.27.0"
 python-multipart = "^0.0.6"
 lib1 = { path = "./ai-service", develop = true }
+lib2 = { path = "../../libs/lib2", develop = true }
 
 [build-system]
 requires = ["poetry-core"]

--- a/libs/lib2/lib2/__init__.py
+++ b/libs/lib2/lib2/__init__.py
@@ -1,0 +1,7 @@
+"""Utilities for DeckChatBot."""
+
+__all__ = ["my_helper"]
+
+def my_helper(x: int) -> int:
+    """Sample helper that doubles the input."""
+    return x * 2


### PR DESCRIPTION
## Summary
- add `lib2` path dependency in app1 and ai-service
- create helper in `libs/lib2`
- demonstrate usage in `backend-ai` `main.py`

## Testing
- `python -m py_compile libs/lib2/lib2/__init__.py`
- `npm test` *(fails: needs jest installation)*

------
https://chatgpt.com/codex/tasks/task_e_685930f3c4008332af33055f622af571