### PR TITLE
Fix backend import path

### DIFF
--- a/backend/backend-ai/main.py
+++ b/backend/backend-ai/main.py
@@ -2,6 +2,13 @@ from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
+import os
+import sys
+
+# Add monorepo libs directory so Python can find local packages
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(os.path.join(ROOT_DIR, "libs"))
+
 from lib2 import my_helper
 
 app = FastAPI()


### PR DESCRIPTION
## Summary
- ensure backend AI service can import local shared libs

## Testing
- `npm test --yes` *(fails: Cannot find module 'supertest')*
- `npx eslint .` *(fails: Cannot find module 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_6859ad8d80cc833294952e365f80a28f

## Summary by Sourcery

Bug Fixes:
- Append the root "libs" directory to sys.path to fix local shared library imports in the backend