### PR TITLE
Fix lib2 import and dependency

### DIFF
--- a/backend/backend-ai/main.py
+++ b/backend/backend-ai/main.py
@@ -2,12 +2,13 @@ from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
-import os
 import sys
+import os
 
-# Add monorepo libs directory so Python can find local packages
-ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.append(os.path.join(ROOT_DIR, "libs"))
+# Add the monorepo root to the path so 'lib2' can be imported
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)
 
 from lib2 import my_helper
 

--- a/backend/backend-ai/pyproject.toml
+++ b/backend/backend-ai/pyproject.toml
@@ -11,7 +11,7 @@ uvicorn = "^0.34.0"
 httpx = "^0.27.0"
 python-multipart = "^0.0.6"
 lib1 = { path = "./ai-service", develop = true }
-lib2 = { path = "../../libs/lib2", develop = true }
+lib2 = { path = "../../lib2", develop = true }
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- update the backend AI service `main.py` to add the repo root to `sys.path`
- adjust `backend/backend-ai/pyproject.toml` to reference lib2 as a local Poetry dependency

## Testing
- `yes | npx jest --runInBand` *(fails: Cannot find module 'supertest')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859bafb2f8c8332bdd4d5734debb2e2