### PR TITLE
Fix docker paths for backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN curl -sSL https://install.python-poetry.org | python3 - && \
 COPY pyproject.toml poetry.lock ./
 
 # Add referenced monorepo packages before install
-COPY ../ai-service ./ai-service
-COPY ../../libs/lib2 ./libs/lib2
+COPY backend/backend-ai/ai-service backend/backend-ai/ai-service
+COPY libs/lib2 libs/lib2
 
 # Install Python dependencies (no dev)
 RUN poetry config virtualenvs.create false && \

--- a/azure-legacy/azure-pipelines.yml
+++ b/azure-legacy/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
         inlineScript: |
           set -e
           echo "Building and pushing Docker images to ACR"
-          az acr build --registry "$ACR_NAME" --image deckchatbot-backend:latest -f Dockerfile .
+          az acr build --registry "$ACR_NAME" --image deckchatbot-backend:latest -f backend/backend-ai/Dockerfile .
           az acr build --registry "$ACR_NAME" --image deckchatbot-frontend:latest -f frontend/Dockerfile ./frontend
 
           echo "Deploying backend container app"

--- a/azure-legacy/azure_setup.sh
+++ b/azure-legacy/azure_setup.sh
@@ -48,7 +48,7 @@ if ! az group show --name "$AZURE_RG" >/dev/null 2>&1; then
 fi
 
 # Build and push Docker images to ACR
-az acr build --registry "$ACR_NAME" --image deckchatbot-backend:latest -f Dockerfile .
+az acr build --registry "$ACR_NAME" --image deckchatbot-backend:latest -f backend/backend-ai/Dockerfile .
 az acr build --registry "$ACR_NAME" --image deckchatbot-frontend:latest -f frontend/Dockerfile ./frontend
 
 # Deploy container apps

--- a/azure-legacy/deploy.yml
+++ b/azure-legacy/deploy.yml
@@ -28,5 +28,5 @@ jobs:
           containerAppName: deckchatbot-backend-app
           resourceGroup: ${{ secrets.AZURE_RG }}
           imageToBuild: ${{ secrets.ACR_NAME }}.azurecr.io/deckchatbot-backend:${{ github.sha }}
-          dockerfilePath: ./Dockerfile
+          dockerfilePath: ./backend/backend-ai/Dockerfile
           targetPort: 8000

--- a/backend/backend-ai/Dockerfile
+++ b/backend/backend-ai/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 - && \
 COPY pyproject.toml poetry.lock ./
 
 # ⛓️ Copy only local packages referenced by pyproject.toml before install
-COPY ../ai-service ./ai-service
+COPY ./ai-service ./ai-service
 COPY ../../libs/lib2 ./libs/lib2
 
 # Install dependencies

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -3,21 +3,21 @@ version: '3.9'
 services:
   backend:
     build:
-      context: ./backend/backend-ai
+      context: ../backend/backend-ai
       dockerfile: Dockerfile
     ports:
       - "8000:8000"
     volumes:
-      - ./backend/backend-ai:/app
+      - ../backend/backend-ai:/app
 
   frontend:
     build:
-      context: ./frontend
+      context: .
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
     volumes:
-      - ./frontend:/app
+      - .:/app
     command: npx serve -s dist  
     environment:
       - REACT_APP_API_BASE_URL=http://backend:8000


### PR DESCRIPTION
## Summary
- fix backend Dockerfile to copy ai-service from correct path
- reference correct directories in monorepo Dockerfile
- correct compose paths for `frontend/docker-compose.yml`
- update Azure scripts to use backend Dockerfile

## Testing
- `npm test` *(fails: requires jest install)*

------
https://chatgpt.com/codex/tasks/task_e_6859f9b503dc8332a6aa7576f6740feb

## Summary by Sourcery

Fix docker path references across compose files, Dockerfiles, and CI scripts to align with the monorepo directory structure

Enhancements:
- Correct Docker contexts and volume mounts in the frontend compose file to reflect the monorepo layout
- Adjust COPY paths in the root and backend Dockerfiles to correctly reference the ai-service and shared libs
- Update Azure pipeline and setup scripts to point to the backend/backend-ai Dockerfile
- Fix deploy config to use the proper Dockerfile path for the backend container