### PR TITLE
Fix ai-service build path dependencies

### DIFF
--- a/backend/backend-ai/ai_service/Dockerfile
+++ b/backend/backend-ai/ai_service/Dockerfile
@@ -14,11 +14,13 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Poetry and set up environment
-COPY pyproject.toml poetry.lock ./
+COPY backend/backend-ai/ai_service/pyproject.toml backend/backend-ai/ai_service/poetry.lock ./
+# Include shared libraries for path dependencies before installing
+COPY libs/lib2 libs/lib2
 RUN curl -sSL https://install.python-poetry.org | python3 - && \
     ln -s /root/.local/bin/poetry /usr/local/bin/poetry && \
     poetry config virtualenvs.create false && \
-    poetry install --no-root
+    poetry install --no-root --only main
 
 # Copy your app code
 COPY . .

--- a/backend/backend-ai/ai_service/pyproject.toml
+++ b/backend/backend-ai/ai_service/pyproject.toml
@@ -7,7 +7,9 @@ authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-lib2 = { path = "../../../libs/lib2", develop = true }
+# When packaged in Docker the libs directory is copied adjacent to this
+# pyproject, so we reference it relative to the working directory.
+lib2 = { path = "libs/lib2", develop = true }
 
 [build-system]
 requires = ["poetry-core"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,9 @@ services:
 
   ai-service:
     build:
-      context: ./backend/backend-ai/ai_service
-      dockerfile: Dockerfile
+      # Use repo root as context so local path dependencies can be copied
+      context: .
+      dockerfile: backend/backend-ai/ai_service/Dockerfile
     ports:
       - "8001:8000"  # backend talks to 8000 inside container, 8001 is host-visible
     healthcheck:


### PR DESCRIPTION
## Summary
- adjust ai-service poetry path for libs
- copy libs during ai-service Docker build and set root build context
- update docker-compose to use repo root context for ai-service

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a174f23e883328e482ee1f79d5ad9