### PR TITLE
Fix ai-service import path and env

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
-AI_SERVICE_URL=http://ai-service:11434
+# Base URL for the AI service used by the backend
+AI_SERVICE_URL=http://ai-service:8000

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 REACT_APP_API_BASE_URL=http://localhost:8000
-AI_SERVICE_URL=http://localhost:8000/analyze-image
+# Base URL for the AI service (no route)
+AI_SERVICE_URL=http://localhost:8001

--- a/backend/backend-ai/ai_service/ai_service/main.py
+++ b/backend/backend-ai/ai_service/ai_service/main.py
@@ -1,8 +1,17 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
-from lib2.square_footage import (
+import os
+import sys
+
+# Ensure local lib2 package can be imported when running outside Docker
+sys.path.append(
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../../../..", "libs")
+    )
+)
+from lib2.lib2.square_footage import (
     extract_text_from_image,
     parse_dimensions_from_text,
-    calculate_square_footage
+    calculate_square_footage,
 )
 import base64
 


### PR DESCRIPTION
## Summary
- correct AI_SERVICE_URL defaults
- adjust ai_service imports so local libs resolve without Docker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a2383600c8332ba53a85baea010c5

## Summary by Sourcery

Fix incorrect AI_SERVICE_URL defaults and adjust ai_service imports for local development without Docker

Bug Fixes:
- Correct default AI_SERVICE_URL values in .env and .env.example files

Enhancements:
- Update ai_service module import paths to resolve local libraries without Docker