### PR TITLE
Fix Docker path for ai_service

### DIFF
--- a/backend/backend-ai/Dockerfile
+++ b/backend/backend-ai/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 - && \
 COPY pyproject.toml poetry.lock ./
 
 # ⛓️ Copy only local packages referenced by pyproject.toml before install
-COPY ./ai_service ./ai_service
+COPY backend/backend-ai/ai_service ./ai_service
 COPY ../../libs/lib2 ./libs/lib2
 
 # Install dependencies


### PR DESCRIPTION
## Summary
- fix path to ai_service in backend Dockerfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a498ea7c48332b196e35e3731685c

## Summary by Sourcery

Bug Fixes:
- Correct the COPY command path for ai_service in backend/backend-ai/Dockerfile