### PR TITLE
Fix Poetry install step in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Poetry
-RUN curl -sSL https://install.python-poetry.org | python3 - && \
-    ln -s /root/.local/bin/poetry /usr/local/bin/poetry
+# Install Poetry via pip for reliability
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir poetry
 
 # Copy pyproject and lockfile
 COPY pyproject.toml poetry.lock ./

--- a/backend/backend-ai/Dockerfile
+++ b/backend/backend-ai/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Poetry globally
-RUN curl -sSL https://install.python-poetry.org | python3 - && \
-    ln -s /root/.local/bin/poetry /usr/local/bin/poetry
+# Install Poetry via pip
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir poetry
 
 # Copy dependency files
 COPY pyproject.toml poetry.lock ./

--- a/backend/backend-ai/ai_service/Dockerfile
+++ b/backend/backend-ai/ai_service/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && \
 COPY backend/backend-ai/ai_service/pyproject.toml backend/backend-ai/ai_service/poetry.lock ./
 # Include shared libraries for path dependencies before installing
 COPY libs/lib2 libs/lib2
-RUN curl -sSL https://install.python-poetry.org | python3 - && \
-    ln -s /root/.local/bin/poetry /usr/local/bin/poetry && \
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir poetry && \
     poetry config virtualenvs.create false && \
     poetry install --no-root --only main
 


### PR DESCRIPTION
## Summary
- install Poetry via pip rather than the remote installer script in Dockerfiles

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a4d3249108332803ecd76a042d9ec