### PR TITLE
Fix ai-service import path

### DIFF
--- a/backend/backend-ai/ai_service/Dockerfile
+++ b/backend/backend-ai/ai_service/Dockerfile
@@ -26,7 +26,8 @@ RUN pip install --no-cache-dir --upgrade pip && \
 COPY . .
 
 # Optional: if you use monorepo imports
-ENV PYTHONPATH="${PYTHONPATH}:/app:/app/../.."
+# Add the ai_service source directory and libs so uvicorn can locate the module
+ENV PYTHONPATH="${PYTHONPATH}:/app:/app/backend/backend-ai/ai_service:/app/libs"
 
 # Set port and start
 ENV PORT=8000


### PR DESCRIPTION
## Summary
- ensure ai_service is on Python path in Docker image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a63c2a46483329f2bceefd5301b94