### PR TITLE
Improve AI service healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository contains the frontend React application, FastAPI backend, and su
    docker compose up --build
    ```
 
+See `docs/docker_healthcheck.md` for troubleshooting container health checks and log inspection tips.
+
 ## Repository structure
 
 - `frontend/` – Node.js Express API with a React frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,10 @@ services:
     entrypoint: /entrypoint.sh
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8000" ]
-      interval: 10s
-      timeout: 5s
-      retries: 3
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 5
 
   ai-service:
     build:
@@ -45,6 +46,7 @@ services:
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8000" ]
-      interval: 10s
-      timeout: 5s
-      retries: 3
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 5

--- a/docs/docker_healthcheck.md
+++ b/docs/docker_healthcheck.md
@@ -1,0 +1,33 @@
+# Docker Healthcheck Tips
+
+This document explains how to troubleshoot Docker container health checks in the AlensDeckBot monorepo.
+
+## Inspecting container state
+
+Use `docker ps` to see the health status:
+
+```bash
+docker ps --format "table {{.Names}}\t{{.Status}}"
+```
+
+To get detailed health information:
+
+```bash
+docker inspect <container_name> --format '{{json .State.Health}}' | jq
+```
+
+Check container logs for failure reasons:
+
+```bash
+docker logs <container_name>
+```
+
+If the health check uses `curl`, you can run the same command manually inside the container:
+
+```bash
+docker exec <container_name> curl -v http://localhost:8000
+```
+
+## Compose dependency management
+
+`backend` depends on `ai-service` and `frontend` depends on `backend` using `depends_on: condition: service_healthy`. This ensures each service starts after its dependency reports healthy. If you require automatic restarts based on health check failures across multiple nodes, consider Docker Swarm or another orchestrator.


### PR DESCRIPTION
## Summary
- improve Docker healthcheck timing for backend and ai-service
- add Docker healthcheck troubleshooting notes
- reference healthcheck docs in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a67e1d82c83328f87be7c6761383b

## Summary by Sourcery

Improve Docker container healthchecks by tuning healthcheck timing parameters and adding troubleshooting documentation

Enhancements:
- Increase healthcheck interval to 30s, timeout to 10s, start_period to 30s, and retries to 5 for backend and ai-service services

Documentation:
- Add docker_healthcheck.md with Docker healthcheck troubleshooting tips
- Reference the new healthcheck troubleshooting guide in the README