### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/backend/backend-ai/ai_service/ai_service/main.py
+++ b/backend/backend-ai/ai_service/ai_service/main.py
@@ -18,7 +18,14 @@ import base64
 app = FastAPI()
 
 @app.get("/")
+async def health_root():
+    """Basic health endpoint for backward compatibility."""
+    return {"status": "ai-service OK"}
+
+
+@app.get("/health")
 async def health():
+    """Dedicated health endpoint used by Docker."""
     return {"status": "ai-service OK"}
 
 @app.post("/analyze-image")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
       - "8001:8000"
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8000" ]
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
       interval: 30s
       timeout: 10s
-      start_period: 30s
-      retries: 5
+      retries: 3
+      start_period: 20s

--- a/docs/docker_healthcheck.md
+++ b/docs/docker_healthcheck.md
@@ -25,7 +25,7 @@ docker logs <container_name>
 If the health check uses `curl`, you can run the same command manually inside the container:
 
 ```bash
-docker exec <container_name> curl -v http://localhost:8000
+docker exec <container_name> curl -v http://localhost:8000/health
 ```
 
 ## Compose dependency management


### PR DESCRIPTION
## Summary
- add `/health` endpoint to AI service
- check `/health` in Docker Compose using CMD-SHELL
- document how to call the health endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a6eff57dc8332b6c7bb32a5ef4d97

## Summary by Sourcery

Implement a standardized healthcheck endpoint in the AI service, integrate it into Docker Compose, and update documentation accordingly.

New Features:
- Add dedicated /health endpoint and a backward-compatible root health endpoint for service health checks

Enhancements:
- Modify Docker Compose healthcheck to use CMD-SHELL against /health and adjust retry/start periods

Documentation:
- Update Healthcheck documentation to reference the /health endpoint