### PR TITLE
Fix Docker build path for lib2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ See `frontend/README.md` for application details.
 The production website at [alensdeckbot.onrender.com](https://alensdeckbot.onrender.com)
 is built from the code in `frontend/src`. Changes to that directory will be
 reflected on the main site after deployment.
+
+## Local library path fix
+
+The backend and AI service both depend on the shared `lib2` package found in
+`libs/lib2`. When building Docker images make sure this directory is included in
+the build context. The provided Dockerfiles copy it explicitly:
+
+```Dockerfile
+COPY libs/lib2 ./libs/lib2
+```
+
+If you see `ModuleNotFoundError: No module named 'lib2.lib2'` during a Docker
+build, verify that the `COPY` line above exists and that your build context is
+the repository root so the `libs` folder is available.

--- a/backend/backend-ai/Dockerfile
+++ b/backend/backend-ai/Dockerfile
@@ -20,7 +20,7 @@ COPY pyproject.toml poetry.lock ./
 
 # ⛓️ Copy only local packages referenced by pyproject.toml before install
 COPY backend/backend-ai/ai_service ./ai_service
-COPY ../../libs/lib2 ./libs/lib2
+COPY libs/lib2 ./libs/lib2
 
 # Install dependencies
 RUN poetry config virtualenvs.create false && \

--- a/backend/backend-ai/ai_service/poetry.lock
+++ b/backend/backend-ai/ai_service/poetry.lock
@@ -238,7 +238,7 @@ develop = true
 
 [package.source]
 type = "directory"
-url = "../../../libs/lib2"
+url = "libs/lib2"
 
 [[package]]
 name = "numpy"

--- a/backend/backend-ai/poetry.lock
+++ b/backend/backend-ai/poetry.lock
@@ -182,7 +182,7 @@ develop = true
 
 [package.source]
 type = "directory"
-url = "../../libs/lib2"
+url = "libs/lib2"
 
 [[package]]
 name = "pydantic"

--- a/backend/backend-ai/pyproject.toml
+++ b/backend/backend-ai/pyproject.toml
@@ -15,7 +15,7 @@ httpx = "^0.27.0"
 python-multipart = "^0.0.6"
 
 # Local monorepo packages
-lib2 = { path = "../../libs/lib2", develop = true }
+lib2 = { path = "libs/lib2", develop = true }
 
 [build-system]
 requires = ["poetry-core"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,7 +11,7 @@ files = []
 develop = true
 
 [package.dependencies]
-lib2 = {path = "../../../libs/lib2", develop = true}
+lib2 = {path = "libs/lib2", develop = true}
 
 [package.source]
 type = "directory"
@@ -114,7 +114,7 @@ develop = true
 [package.dependencies]
 fastapi = "^0.115.0"
 httpx = "^0.27.0"
-lib2 = {path = "../../libs/lib2", develop = true}
+lib2 = {path = "libs/lib2", develop = true}
 python-multipart = "^0.0.6"
 uvicorn = "^0.34.0"
 


### PR DESCRIPTION
## Summary
- ensure backend Dockerfile copies lib2 from context
- update pyproject and lock files to reference lib2 relative to container root
- document local library path fix

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a717770648332b71fef02284abbbd