### PR TITLE
Fix backend service healthcheck endpoint

### DIFF
--- a/backend/backend-ai/README.md
+++ b/backend/backend-ai/README.md
@@ -21,7 +21,7 @@ uvicorn API.api:app --reload
 
 ## Test health endpoint
 
-[Check health endpoint](http://localhost:8000/)
+[Check health endpoint](http://localhost:8000/health)
 That clarity helps the AI parse the flow precisely .
 
 📦 3. Show core concepts/code signature blocks

--- a/backend/backend-ai/backend_ai/main.py
+++ b/backend/backend-ai/backend_ai/main.py
@@ -8,6 +8,12 @@ app = FastAPI()
 def root():
     return {"message": "Deckbot AI backend is alive!"}
 
+
+@app.get("/health")
+def health():
+    """Health check endpoint used by Docker."""
+    return {"status": "backend OK"}
+
 class AnalyzeImageResponse(BaseModel):
     result: str
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
     entrypoint: /entrypoint.sh
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8000" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8000/health" ]
       interval: 30s
       timeout: 10s
       start_period: 30s


### PR DESCRIPTION
## Summary
- add `/health` endpoint for backend
- update Docker Compose healthcheck path
- document new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad5f89f84833287a98023c5725f32