### PR TITLE
Fix Windows CRLF issues for Docker scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+Dockerfile text eol=lf

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ This repository contains the frontend React application, FastAPI backend, and su
 
 See `docs/docker_healthcheck.md` for troubleshooting container health checks and log inspection tips.
 
+### Windows line ending fix
+If Docker fails with `/usr/bin/env: bash\r`, ensure shell scripts use LF line endings. Configure Git on Windows:
+```bash
+ git config --global core.autocrlf input
+```
+This prevents CRLF errors when running containers.
+
+
 ## Repository structure
 
 - `frontend/` – Node.js Express API with a React frontend


### PR DESCRIPTION
## Summary
- normalize shell script line endings via .gitattributes
- document how Windows users can avoid `/usr/bin/env: bash\r` errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b057253bc8332b42741d6ff252844