### PR TITLE
Fix ai-service Dockerfile path and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ reflected on the main site after deployment.
 ## Local library path fix
 
 The backend and AI service both depend on the shared `lib2` package found in
-`libs/lib2`. When building Docker images make sure this directory is included in
+`backend/backend-ai/libs/lib2`. When building Docker images make sure this directory is included in
 the build context. The provided Dockerfiles copy it explicitly:
 
 ```Dockerfile
-COPY libs/lib2 ./libs/lib2
+COPY backend/backend-ai/libs/lib2 libs/lib2
 ```
 
 If you see `ModuleNotFoundError: No module named 'lib2.lib2'` during a Docker

--- a/backend/backend-ai/ai_service/Dockerfile
+++ b/backend/backend-ai/ai_service/Dockerfile
@@ -13,8 +13,9 @@ RUN apt-get update && \
     libtesseract-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy pyproject.toml and poetry.lock
-COPY pyproject.toml poetry.lock ./
+# Copy ai-service's pyproject and lockfile
+COPY backend/backend-ai/ai_service/pyproject.toml ./pyproject.toml
+COPY backend/backend-ai/ai_service/poetry.lock ./poetry.lock
 
 # Copy shared libs needed for install
 COPY backend/backend-ai/libs/lib2 libs/lib2
@@ -26,7 +27,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     poetry install --no-root --only main
 
 # Copy app code
-COPY . .
+COPY backend/backend-ai/ai_service/ai_service ./ai_service
 
 # Optional: set PYTHONPATH
 ARG PYTHONPATH=""
@@ -35,7 +36,7 @@ ENV PYTHONPATH=${PYTHONPATH}:/app:/app/ai_service:/app/libs
 ENV PORT=8000
 EXPOSE ${PORT}
 
-COPY entrypoint.sh /entrypoint.sh
+COPY backend/backend-ai/ai_service/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 CMD ["/entrypoint.sh"]
 


### PR DESCRIPTION
## Summary
- fix ai-service Dockerfile to use correct paths
- update README with correct lib2 location

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b093b15e08332a7fa3433e590631b

## Summary by Sourcery

Fix path references in the AI service Dockerfile and update README instructions accordingly.

Bug Fixes:
- Correct COPY directives in ai-service Dockerfile to use the proper backend/backend-ai/ai_service subpaths for pyproject.toml, poetry.lock, application code, and entrypoint.

Documentation:
- Update README to reference the correct backend/backend-ai/libs/lib2 location and adjust the Dockerfile example accordingly.