### PR TITLE
Integrate Ollama REST vision endpoint

### DIFF
--- a/backend/app2/app2/main.py
+++ b/backend/app2/app2/main.py
@@ -15,7 +15,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-AI_SERVICE_URL = os.getenv("AI_SERVICE_URL", "http://ai-service:8000/analyze-image")
+AI_SERVICE_URL = os.getenv("AI_SERVICE_URL", "http://ai-service:8000/vision-query")
 
 @app.get("/")
 async def health():

--- a/backend/backend-ai/api/routes/analyze.py
+++ b/backend/backend-ai/api/routes/analyze.py
@@ -1,30 +1,27 @@
 from fastapi import APIRouter, UploadFile, File
 from fastapi.responses import JSONResponse
-import subprocess
-import tempfile
+import base64
+import requests
 import json
-import os
 
 router = APIRouter()
 
+@router.post("/vision-query")
+async def vision_query(file: UploadFile = File(...), prompt: str = "Describe image"):
+    """Send the uploaded image to the local Ollama LLaVA REST API."""
+    img_bytes = await file.read()
+    data = base64.b64encode(img_bytes).decode()
+    try:
+        resp = requests.post(
+            "http://localhost:11434/api/generate",
+            json={"model": "llava-deckbot", "prompt": prompt, "images": [data]},
+        )
+        return resp.json()
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
 @router.post("/analyze-image")
 async def analyze_image(file: UploadFile = File(...)):
-    """Run the deckchatbot model against an uploaded image."""
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".jpg") as tmp:
-        tmp.write(await file.read())
-        tmp_path = tmp.name
-
-    command = ["ollama", "run", "deckchatbot", "--image", tmp_path]
-
-    try:
-        result = subprocess.run(command, capture_output=True, text=True, check=True)
-        output = result.stdout
-        json_start = output.find("{")
-        json_end = output.rfind("}") + 1
-        parsed = json.loads(output[json_start:json_end])
-    except Exception as e:
-        return JSONResponse(status_code=500, content={"error": str(e), "raw_output": output})
-    finally:
-        os.remove(tmp_path)
-
-    return parsed
+    """Backward compatible wrapper around vision_query."""
+    return await vision_query(file)

--- a/backend/backend-ai/llama_integration/llava_runner.py
+++ b/backend/backend-ai/llama_integration/llava_runner.py
@@ -9,7 +9,7 @@ def run_llava(image_bytes: bytes, prompt: str = "Describe this image") -> str:
         resp = requests.post(
             "http://localhost:11434/api/generate",
             json={
-                "model": "llava-llama3",
+                "model": "llava-deckbot",
                 "prompt": prompt,
                 "images": [encoded],
                 "stream": False,

--- a/backend/backend-ai/llama_integration/predict.py
+++ b/backend/backend-ai/llama_integration/predict.py
@@ -11,7 +11,7 @@ def run_model(image_bytes: bytes, prompt: str = "What shape is this deck?") -> s
     response = requests.post(
         "http://localhost:11434/api/generate",
         json={
-            "model": "llava-llama3",
+            "model": "llava-deckbot",
             "prompt": prompt,
             "images": [encoded_image],
             "stream": False

--- a/backend/backend-ai/visionRouter.js
+++ b/backend/backend-ai/visionRouter.js
@@ -13,7 +13,7 @@ const router = express.Router();
 const upload = multer({ dest: 'uploads/' });
 
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
-const LLAVA_MODEL_NAME = process.env.LLAVA_MODEL_NAME || 'llava-llama3';
+const LLAVA_MODEL_NAME = process.env.LLAVA_MODEL_NAME || 'llava-deckbot';
 
 // Define rate limiter: maximum of 100 requests per 15 minutes
 const analyzeRateLimiter = rateLimit({

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -8,4 +8,4 @@ runcmd:
   - curl -fsSL https://ollama.com/install.sh | sh
   - systemctl enable ollama
   - systemctl start ollama
-  - su - alens -c "ollama run llava"
+  - su - alens -c "ollama run llava-deckbot"

--- a/frontend/src/components/DeckBuilderUI.tsx
+++ b/frontend/src/components/DeckBuilderUI.tsx
@@ -34,7 +34,7 @@ export default function DeckBuilderUI() {
       const API_URL =
         process.env.REACT_APP_API_BASE_URL || "https://deckchatbot-backend.onrender.com";
       try {
-        await axios.post(`${API_URL}/analyze-image`, formData, {
+        await axios.post(`${API_URL}/vision-query`, formData, {
           headers: { "Content-Type": "multipart/form-data" },
         });
         const url = URL.createObjectURL(file);

--- a/frontend/src/components/ImageAnalyzer.jsx
+++ b/frontend/src/components/ImageAnalyzer.jsx
@@ -13,7 +13,7 @@ export default function ImageAnalyzer() {
     formData.append("file", file);
     try {
       const API_URL = process.env.REACT_APP_API_BASE_URL || "https://deckchatbot-backend.onrender.com";
-      const res = await axios.post(`${API_URL}/analyze-image`, formData);
+      const res = await axios.post(`${API_URL}/vision-query`, formData);
       setResult(res.data);
     } catch (err) {
       console.error(err);

--- a/unified-site/server.js
+++ b/unified-site/server.js
@@ -7,7 +7,7 @@ const PORT = process.env.PORT || 3000;
 
 // ✅ Proxy AI API requests to backend
 app.use(
-  "/analyze-image",
+  "/vision-query",
   createProxyMiddleware({
     target: "https://deckchatbot-backend.onrender.com",
     changeOrigin: true,


### PR DESCRIPTION
## Summary
- add `/vision-query` endpoint using Ollama REST API
- call new endpoint from legacy `/analyze-image`
- update llava model name references to `llava-deckbot`
- proxy new endpoint through unified site and update frontend
- adjust cloud-init to run the new model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b5e6879288332a8f8c1cdc42050bc

## Summary by Sourcery

Integrate the Ollama REST vision endpoint by introducing a new `vision-query` route, migrating existing image analysis workflows to it, switching model references to `llava-deckbot`, and adjusting deployment and client configurations accordingly.

New Features:
- Add `/vision-query` REST endpoint for image analysis via Ollama LLaVA API

Enhancements:
- Wrap legacy `/analyze-image` endpoint to call `vision-query` for backward compatibility
- Update AI service URL defaults and llama-integration modules to use the `llava-deckbot` model
- Modify cloud-init to run `llava-deckbot` on startup
- Update frontend components and unified-site proxy to call `/vision-query` instead of `/analyze-image`