### PR TITLE
Configure Docker subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This repository contains the frontend React application, FastAPI backend, and su
    ```bash
    docker compose up --build
    ```
+   Docker Compose creates a custom `decknet` network with the subnet
+   `192.168.65.0/24`. Ensure this range does not conflict with existing
+   networks on your machine or adjust the subnet in `docker-compose.yml`.
 
 See `docs/docker_healthcheck.md` for troubleshooting container health checks and log inspection tips.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    networks:
+      - decknet
 
   backend:
     build:
@@ -36,6 +38,8 @@ services:
       timeout: 10s
       start_period: 30s
       retries: 5
+    networks:
+      - decknet
 
   ai-service:
     build:
@@ -50,3 +54,12 @@ services:
       timeout: 10s
       retries: 3
       start_period: 20s
+    networks:
+      - decknet
+
+networks:
+  decknet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.65.0/24


### PR DESCRIPTION
## Summary
- document the `decknet` subnet in the README
- attach services to a custom Docker network with subnet `192.168.65.0/24`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b69fa2ee08332b3aa3cc61d87ce50