### PR TITLE
Fix service routes and compose paths

### DIFF
--- a/apps/frontend/docker-compose.yml
+++ b/apps/frontend/docker-compose.yml
@@ -3,12 +3,12 @@ version: '3.9'
 services:
   backend:
     build:
-      context: ../backend/backend-ai
+      context: ../backend
       dockerfile: Dockerfile
     ports:
       - "8000:8000"
     volumes:
-      - ../backend/backend-ai:/app
+      - ../backend:/app
 
   frontend:
     build:

--- a/apps/frontend/src/components/FullAnalyzer.jsx
+++ b/apps/frontend/src/components/FullAnalyzer.jsx
@@ -22,7 +22,8 @@ const UploadAnalyze = () => {
     setError(null);
 
     try {
-      const res = await axios.post('http://localhost:8000/full-analyze', formData, {
+      const API_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+      const res = await axios.post(`${API_URL}/full-analyze`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
       setResult(res.data);

--- a/config/poetry.lock
+++ b/config/poetry.lock
@@ -15,7 +15,7 @@ lib2 = {path = "libs/lib2", develop = true}
 
 [package.source]
 type = "directory"
-url = "backend/backend-ai/ai_service"
+url = "../apps/ai-service"
 
 [[package]]
 name = "annotated-types"
@@ -62,7 +62,7 @@ files = []
 develop = true
 
 [package.dependencies]
-ai-service = {path = "../backend-ai/ai_service", develop = true}
+ai-service = {path = "../apps/ai-service", develop = true}
 requests = "^2.26"
 
 [package.source]
@@ -120,7 +120,7 @@ uvicorn = "^0.34.0"
 
 [package.source]
 type = "directory"
-url = "backend/backend-ai"
+url = "../apps/backend"
 
 [[package]]
 name = "certifi"

--- a/config/pyproject.toml
+++ b/config/pyproject.toml
@@ -16,11 +16,11 @@ pytest = "^6.2"
 
 
 [tool.poetry.group.app.dependencies]
-backend-ai = { path = "backend/backend-ai", develop = true }
-app2 = { path = "backend/app2", develop = true }
+backend-ai = { path = "../apps/backend", develop = true }
+app2 = { path = "../apps/backend/app2", develop = true }
 
 [tool.poetry.group.lib.dependencies]
-ai-service = { path = "backend/backend-ai/ai_service", develop = true }
+ai-service = { path = "../apps/ai-service", develop = true }
 lib2 = { path = "libs/lib2", develop = true }  # adjust this name too if needed
 
 


### PR DESCRIPTION
## Summary
- proxy `/full-analyze` endpoint from backend to ai-service
- point analyze endpoint to correct ai-service route
- update docker compose backend path
- make FullAnalyzer use API_URL env var
- update Poetry config paths to new service locations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2980e9988332871ac29d5a597265