### PR TITLE
Add steps calculation endpoint

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -88,6 +88,7 @@ npm test
 
 - `POST /calculate-deck-materials` - Calculate materials for single deck
 - `POST /calculate-multi-shape` - Calculate for multiple geometric shapes
+- `POST /calculate-steps` - Determine stair count from deck height
 
 ### File Upload
 

--- a/apps/frontend/controllers/stepsController.js
+++ b/apps/frontend/controllers/stepsController.js
@@ -1,0 +1,15 @@
+const { calculateSteps, ftInToDecimal } = require('../src/utils/geometry');
+
+function calculateStepsEndpoint(req, res) {
+  const { height } = req.body;
+  const heightFt = ftInToDecimal(height);
+  if (!heightFt || isNaN(heightFt) || heightFt <= 0) {
+    return res.status(400).json({
+      errors: [{ msg: 'Valid height is required' }]
+    });
+  }
+  const steps = calculateSteps(heightFt * 12); // convert feet to inches
+  res.json({ steps });
+}
+
+module.exports = { calculateStepsEndpoint };

--- a/apps/frontend/routes/index.js
+++ b/apps/frontend/routes/index.js
@@ -8,6 +8,7 @@ const skirtingRoutes = require('./skirting');
 const deckCalcRoutes = require('./deckCalc');
 const digitalizeRoutes = require('./digitalize');
 const uploadDrawingRoutes = require('./uploadDrawing');
+const stepsRoutes = require('./steps');
 
 const router = express.Router();
 
@@ -28,5 +29,6 @@ router.use('/calculate-skirting', skirtingRoutes);
 router.use('/calculate-deck-materials', deckCalcRoutes);
 router.use('/digitalize-drawing', digitalizeRoutes);
 router.use('/upload-drawing', uploadDrawingRoutes);
+router.use('/calculate-steps', stepsRoutes);
 
 module.exports = router;

--- a/apps/frontend/routes/steps.js
+++ b/apps/frontend/routes/steps.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { calculateStepsEndpoint } = require('../controllers/stepsController');
+
+const router = express.Router();
+
+router.post('/', calculateStepsEndpoint);
+
+module.exports = router;

--- a/tests/__tests__/stepsEndpoint.test.js
+++ b/tests/__tests__/stepsEndpoint.test.js
@@ -1,0 +1,27 @@
+const request = require('supertest');
+
+jest.mock('openai', () => ({
+  chat: { completions: { create: jest.fn().mockResolvedValue({ choices: [{ message: { content: 'mocked' } }] }) } }
+}), { virtual: true });
+jest.mock('tesseract.js', () => ({ recognize: jest.fn() }), { virtual: true });
+jest.mock('uuid', () => ({ v4: jest.fn(() => 'uuid') }), { virtual: true });
+jest.mock('potrace', () => ({ trace: jest.fn() }), { virtual: true });
+
+const { app } = require('../server.cjs');
+
+describe('steps endpoint', () => {
+  test('/calculate-steps basic', async () => {
+    const res = await request(app)
+      .post('/calculate-steps')
+      .send({ height: "32" });
+    expect(res.status).toBe(200);
+    expect(res.body.steps).toBe(5);
+  });
+
+  test('/calculate-steps invalid', async () => {
+    const res = await request(app)
+      .post('/calculate-steps')
+      .send({ height: 'foo' });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/calculate-steps` API endpoint for stair counts
- document the new endpoint
- test basic usage

## Testing
- `npm test` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_685cd132b6f08332b6e82da692056109

## Summary by Sourcery

Add a new `/calculate-steps` API endpoint that validates input height and returns the required stair count.

New Features:
- Introduce `/calculate-steps` endpoint in the router to calculate stair count
- Implement `calculateStepsEndpoint` controller to parse, validate, and convert height to step count

Documentation:
- Add `/calculate-steps` usage to the frontend README

Tests:
- Add integration tests for valid and invalid `/calculate-steps` requests